### PR TITLE
Fix profile page scraper to match Github.com change

### DIFF
--- a/lib/page.rb
+++ b/lib/page.rb
@@ -5,7 +5,7 @@ class Page
     if chunk != nil
       @streak = get_streak(chunk)
     else
-      @streak = 0
+      @streak = "error"
     end
   end
 
@@ -24,7 +24,7 @@ class Page
   end
 
   def chunk(page)
-    location = page.index '<div class="col contrib-streak">'
+    location = page.index '<div class="table-column contrib-streak">'
     if location != nil
       page[location..location+100]
     end

--- a/lib/tasks/large_streaks.rake
+++ b/lib/tasks/large_streaks.rake
@@ -5,7 +5,9 @@ namespace :large_streaks do
     connection = Connection.new
     User.where('longest_streak > 365').find_each(batch_size: 10) do |user|
       page = Page.new(user.username)
-      user.update_attribute(:longest_streak, page.streak)
+      if page.streak != "error"
+        user.update_attribute(:longest_streak, page.streak)
+      end
     end
   end
 end


### PR DESCRIPTION
Github.com apparently changed the div name on the profile page that contains the longest streak and so the page scraper failed to run correctly.
