### PR TITLE
check that it won't override current streak with a smaller one

### DIFF
--- a/lib/tasks/large_streaks.rake
+++ b/lib/tasks/large_streaks.rake
@@ -6,7 +6,9 @@ namespace :large_streaks do
     User.where('longest_streak > 365').find_each(batch_size: 10) do |user|
       page = Page.new(user.username)
       if page.streak != "error"
-        user.update_attribute(:longest_streak, page.streak)
+        if page.streak.to_i >= user.longest_streak
+          user.update_attribute(:longest_streak, page.streak)
+        end
       end
     end
   end

--- a/lib/tasks/new_streaks.rake
+++ b/lib/tasks/new_streaks.rake
@@ -7,7 +7,9 @@ namespace :new_streaks do
     User.find_each(start: last, batch_size: 10) do |user|
       page = Page.new(user.username)
       if page.streak != "error"
-        user.update_attribute(:longest_streak, page.streak)
+        if page.streak.to_i >= user.longest_streak
+          user.update_attribute(:longest_streak, page.streak)
+        end
       end
     end
   end

--- a/lib/tasks/streaks.rake
+++ b/lib/tasks/streaks.rake
@@ -7,7 +7,9 @@ namespace :streaks do
     User.find_each(start: last, batch_size: 10) do |user|
       page = Page.new(user.username)
       if page.streak != "error"
-        user.update_attribute(:longest_streak, page.streak)
+        if page.streak.to_i >= user.longest_streak
+          user.update_attribute(:longest_streak, page.streak)
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes issue #16.

It checks to make sure that new streaks don't overwrite streaks already stored in the db that are larger.
